### PR TITLE
Call update-alternatives to make gcc-10 and g++10 the new defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ LABEL maintainer="dev@anteru.net"
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -q && apt-get upgrade -qy && apt-get install -qy make g++-10 python3-pip python3-venv git
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
 RUN pip3 install --upgrade pip
 RUN apt-get install -qy wget
 RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.22.0/cmake-3.22.0-Linux-x86_64.sh


### PR DESCRIPTION
While using this image in CI, I noticed that the default `g++` and `gcc` versions used in builds is still 9.3.0. Calling `update-alternatives` with a suitable priority should make the GCC 10 versions the defaults.